### PR TITLE
DM_csproj_xml_tags_fix

### DIFF
--- a/EcoSentinel/EcoSentinel.csproj
+++ b/EcoSentinel/EcoSentinel.csproj
@@ -67,13 +67,13 @@
 	</ItemGroup>
 
 	<ItemGroup>
-
 		<EmbeddedResource Include="appsettings.json" />
 		<None Update="appsettings.json">
 			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
 		</None>
 	</ItemGroup>
 
+	<ItemGroup>
 	  <Compile Update="View\HistoricalPage.xaml.cs">
 	    <DependentUpon>HistoricalPage.xaml</DependentUpon>
 	  </Compile>


### PR DESCRIPTION
There was an "ItemGroup" tag removed from the EcoSentinel.csproj code during conflict resolution for https://github.com/Dannycarey23/EcoSentinel/pull/26 I have re-added this as well as updated the whitespace for the tag above it