### PR TITLE
Map installed on Weather, Water & Air Sensor pages

### DIFF
--- a/EcoSentinel/EcoSentinel.sln
+++ b/EcoSentinel/EcoSentinel.sln
@@ -1,0 +1,24 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.2.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EcoSentinel", "EcoSentinel.csproj", "{A7F7A483-8FA4-9F07-0F35-B682F370371D}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{A7F7A483-8FA4-9F07-0F35-B682F370371D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A7F7A483-8FA4-9F07-0F35-B682F370371D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A7F7A483-8FA4-9F07-0F35-B682F370371D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A7F7A483-8FA4-9F07-0F35-B682F370371D}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {D0F134F3-B3EE-4462-8874-AFFC601587A6}
+	EndGlobalSection
+EndGlobal

--- a/EcoSentinel/View/AirSensorPage.xaml
+++ b/EcoSentinel/View/AirSensorPage.xaml
@@ -21,10 +21,7 @@
             <local:HeaderPage/>
         </Grid>
 
-        <Grid Grid.Row="1" >
-            <Grid.RowDefinitions>
-                <RowDefinition Height="*"/>
-            </Grid.RowDefinitions>
+        <Grid Grid.Row="1" >            
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="*"/>
@@ -67,10 +64,6 @@
         </Grid>
 
         <Grid Grid.Row="2">
-            <Grid.RowDefinitions>
-                <RowDefinition Height="*"/>
-            </Grid.RowDefinitions>
-
             <Border x:Name="sensorDataFrame"
                 Grid.Row="0"
                 Grid.Column="0" 

--- a/EcoSentinel/View/WaterSensorPage.xaml
+++ b/EcoSentinel/View/WaterSensorPage.xaml
@@ -20,10 +20,7 @@
             <local:HeaderPage/>
         </Grid>
 
-        <Grid Grid.Row="1" >
-            <Grid.RowDefinitions>
-                <RowDefinition Height="*"/>
-            </Grid.RowDefinitions>
+        <Grid Grid.Row="1" >           
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="*"/>
@@ -66,10 +63,6 @@
         </Grid>
 
         <Grid Grid.Row="2">
-            <Grid.RowDefinitions>
-                <RowDefinition Height="*"/>
-            </Grid.RowDefinitions>
-
             <Border x:Name="sensorDataFrame"
                 Grid.Row="0"
                 Grid.Column="0" 

--- a/EcoSentinel/View/WeatherSensorPage.xaml
+++ b/EcoSentinel/View/WeatherSensorPage.xaml
@@ -18,9 +18,6 @@
             </Grid>
             
             <Grid Grid.Row="1" >
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="*"/>
-                </Grid.RowDefinitions>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*"/>
                     <ColumnDefinition Width="*"/>
@@ -62,11 +59,7 @@
                 </Border>
             </Grid>
         
-            <Grid Grid.Row="2">
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="*"/>
-                </Grid.RowDefinitions>            
-            
+            <Grid Grid.Row="2">           
                 <Border x:Name="sensorDataFrame"
                         Grid.Row="0"
                         Grid.Column="0" 


### PR DESCRIPTION
Weather, Water & Air Sensor pages now have maps with their own coordinates. 

Also updated the "NodeFrame" and SensorFrame" to look more like a table and to provide more of an indication of what they will look like upon completion.

Concerns:
- WebView exposes the API key. This will need to be hidden before the repo is made public.
- Using the google maps URL instead of the maps SDK for android means fixed heights & widths need to be used. Ideally this would be responsive and fill the space
- DRY Principle - I should probably refactor this to reuse the repeated code.