### PR TITLE
DM_Historical_Data_Page

### DIFF
--- a/EcoSentinel/AppShell.xaml
+++ b/EcoSentinel/AppShell.xaml
@@ -32,5 +32,9 @@
         Title="LoginPage"
         ContentTemplate="{DataTemplate view:LoginPage}"
         Route="LoginPage" />
+        <ShellContent 
+        Title="Historical Data"
+        ContentTemplate="{DataTemplate view:HistoricalDataPage}"
+        Route="HistoricalDataPage" />
     
 </Shell>

--- a/EcoSentinel/AppShell.xaml.cs
+++ b/EcoSentinel/AppShell.xaml.cs
@@ -12,5 +12,6 @@ public partial class AppShell : Shell
 		Routing.RegisterRoute(nameof(WaterSensorPage), typeof(WaterSensorPage));
 		Routing.RegisterRoute(nameof(WeatherSensorPage), typeof(WeatherSensorPage));
 		Routing.RegisterRoute(nameof(LoginPage), typeof(LoginPage));
+		Routing.RegisterRoute(nameof(HistoricalDataPage), typeof(HistoricalDataPage));
 	}
 }

--- a/EcoSentinel/MauiProgram.cs
+++ b/EcoSentinel/MauiProgram.cs
@@ -53,6 +53,9 @@ public static class MauiProgram
 		builder.Services.AddSingleton<UserService>();
 		builder.Services.AddTransient<FooterPageViewModel>();
 		
+		builder.Services.AddTransient<HistoricalDataPageViewModel>();
+		builder.Services.AddTransient<HistoricalDataPage>();
+		
 
 #if DEBUG
 		builder.Logging.AddDebug();

--- a/EcoSentinel/Model/DataTypeTemplateSelector.cs
+++ b/EcoSentinel/Model/DataTypeTemplateSelector.cs
@@ -1,0 +1,25 @@
+using Microsoft.Maui.Controls;
+using EcoSentinel.ViewModel;
+
+namespace EcoSentinel.Selectors
+{
+    public class DataTypeTemplateSelector : DataTemplateSelector
+    {
+        public DataTemplate AirDataTemplate { get; set; }
+        public DataTemplate WaterDataTemplate { get; set; }
+        public DataTemplate WeatherDataTemplate { get; set; }
+
+        protected override DataTemplate OnSelectTemplate(object item, BindableObject container)
+        {
+            var viewModel = (HistoricalDataPageViewModel)((BindableObject)container).BindingContext;
+
+            return viewModel.CurrentDataType switch
+            {
+                "air" => AirDataTemplate,
+                "water" => WaterDataTemplate,
+                "weather" => WeatherDataTemplate,
+                _ => null,
+            };
+        }
+    }
+}

--- a/EcoSentinel/View/HistoricalDataPage.xaml
+++ b/EcoSentinel/View/HistoricalDataPage.xaml
@@ -3,8 +3,54 @@
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:local="clr-namespace:EcoSentinel.View"
-    x:Class="EcoSentinel.HistoricalDataPage">
-
+    xmlns:selectors="clr-namespace:EcoSentinel.Selectors"
+    x:Class="EcoSentinel.View.HistoricalDataPage">
+    <ContentPage.Resources>
+        <ResourceDictionary>
+            <!--DATA TEMPLATES-->
+            <DataTemplate x:Key="AirDataTemplate">
+                <Grid ColumnDefinitions="*,*,*,*,*,*,*,*">
+                    <Label Grid.Column="0" Text="{Binding sensorType}" FontSize="14" Padding="5"/>
+                    <Label Grid.Column="1" Text="{Binding zone}" FontSize="14" Padding="5"/>
+                    <Label Grid.Column="2" Text="{Binding agglomeration}" FontSize="14" Padding="5"/>
+                    <Label Grid.Column="3" Text="{Binding date}" FontSize="14" Padding="5"/>
+                    <Label Grid.Column="4" Text="{Binding time}" FontSize="14" Padding="5"/>
+                    <Label Grid.Column="5" Text="{Binding nitrogenDioxide}" FontSize="14" Padding="5"/>
+                    <Label Grid.Column="6" Text="{Binding sulfurDioxide}" FontSize="14" Padding="5"/>
+                    <Label Grid.Column="7" Text="{Binding pmTwoPointFive}" FontSize="14" Padding="5"/>
+                </Grid>
+            </DataTemplate>
+            <DataTemplate x:Key="WaterDataTemplate">
+                <Grid ColumnDefinitions="*,*,*,*,*,*,*">
+                    <Label Grid.Column="0" Text="{Binding sensorType}" FontSize="14" Padding="5"/>
+                    <Label Grid.Column="1" Text="{Binding date}" FontSize="14" Padding="5"/>
+                    <Label Grid.Column="2" Text="{Binding time}" FontSize="14" Padding="5"/>
+                    <Label Grid.Column="3" Text="{Binding nitrateMgl1}" FontSize="14" Padding="5"/>
+                    <Label Grid.Column="4" Text="{Binding nitrateLessThanMgL1}" FontSize="14" Padding="5"/>
+                    <Label Grid.Column="5" Text="{Binding phosphateMgl1}" FontSize="14" Padding="5"/>
+                    <Label Grid.Column="6" Text="{Binding ecCfu100ml}" FontSize="14" Padding="5"/>                                    
+                </Grid>
+            </DataTemplate>
+            <DataTemplate x:Key="WeatherDataTemplate">
+                <Grid ColumnDefinitions="*,*,*,*,*,*,*,*,*,*">
+                    <Label Grid.Column="0" Text="{Binding sensorType}" FontSize="14" Padding="5"/>
+                    <Label Grid.Column="1" Text="{Binding elevation}" FontSize="14" Padding="5"/>
+                    <Label Grid.Column="2" Text="{Binding utcOffsetSeconds}" FontSize="14" Padding="5"/>
+                    <Label Grid.Column="3" Text="{Binding timezone}" FontSize="14" Padding="5"/>
+                    <Label Grid.Column="4" Text="{Binding date}" FontSize="14" Padding="5"/>
+                    <Label Grid.Column="5" Text="{Binding time}" FontSize="14" Padding="5"/>
+                    <Label Grid.Column="6" Text="{Binding temp2m}" FontSize="14" Padding="5"/>
+                    <Label Grid.Column="7" Text="{Binding relativeHumidity2m}" FontSize="14" Padding="5"/>
+                    <Label Grid.Column="8" Text="{Binding windSpeed}" FontSize="14" Padding="5"/>
+                    <Label Grid.Column="9" Text="{Binding windDirection}" FontSize="14" Padding="5"/>
+                </Grid>
+            </DataTemplate>
+            <selectors:DataTypeTemplateSelector x:Key="DataTypeTemplateSelector"
+                AirDataTemplate="{StaticResource AirDataTemplate}"
+                WaterDataTemplate="{StaticResource WaterDataTemplate}"
+                WeatherDataTemplate="{StaticResource WeatherDataTemplate}"/>
+        </ResourceDictionary>
+    </ContentPage.Resources>
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="80"/>        
@@ -56,50 +102,21 @@
 
         <Grid Grid.Row="2">
             <Border x:Name="sensorDataFrame"
-            Grid.Row="0"
-            Grid.Column="0" 
-            Margin="5"
-            Padding="10">
+                    Grid.Row="0"
+                    Margin="5"
+                    Padding="10">
                 <Grid>
                     <Grid.RowDefinitions>
-                        <RowDefinition Height="Auto"/>
                         <RowDefinition Height="*" />
-                        </Grid.RowDefinitions>
+                    </Grid.RowDefinitions>
 
-                    <Grid Grid.Row="0"
-                          BackgroundColor="lightgray"
-                          ColumnDefinitions="*,*,*,*,*,*,*,*"
-                          Padding="5">
-                        <Label Grid.Column="0" Text="Sensor Type" FontSize="16" FontAttributes="Bold"/>
-                        <Label Grid.Column="1" Text="Zone" FontSize="16" FontAttributes="Bold"/>
-                        <Label Grid.Column="2" Text="Agglomeration" FontSize="16" FontAttributes="Bold"/>
-                        <Label Grid.Column="3" Text="Date" FontSize="16" FontAttributes="Bold"/>
-                        <Label Grid.Column="4" Text="Time" FontSize="16" FontAttributes="Bold"/>
-                        <Label Grid.Column="5" Text="NO₂" FontSize="16" FontAttributes="Bold"/>
-                        <Label Grid.Column="6" Text="SO₂" FontSize="16" FontAttributes="Bold"/>
-                        <Label Grid.Column="7" Text="PM2.5" FontSize="16" FontAttributes="Bold"/>
-                    </Grid>
-
-                    <CollectionView Grid.Row="1" ItemsSource="{Binding AirData}">
-                        <CollectionView.ItemTemplate>
-                            <DataTemplate>
-                                <Grid ColumnDefinitions="*,*,*,*,*,*,*,*">
-                                    <Label Grid.Column="0" Text="{Binding sensorType}" FontSize="14" Padding="5"/>
-                                    <Label Grid.Column="1" Text="{Binding zone}" FontSize="14" Padding="5"/>
-                                    <Label Grid.Column="2" Text="{Binding agglomeration}" FontSize="14" Padding="5"/>
-                                    <Label Grid.Column="3" Text="{Binding date}" FontSize="14" Padding="5"/>
-                                    <Label Grid.Column="4" Text="{Binding time}" FontSize="14" Padding="5"/>
-                                    <Label Grid.Column="5" Text="{Binding nitrogenDioxide}" FontSize="14" Padding="5"/>
-                                    <Label Grid.Column="6" Text="{Binding sulfurDioxide}" FontSize="14" Padding="5"/>
-                                    <Label Grid.Column="7" Text="{Binding pmTwoPointFive}" FontSize="14" Padding="5"/>
-                                </Grid>
-                            </DataTemplate>
-                        </CollectionView.ItemTemplate>
-                    </CollectionView>
+                    <!-- Data Row -->
+                    <CollectionView Grid.Row="1" 
+                        ItemsSource="{Binding CurrentData}"
+                        ItemTemplate="{StaticResource DataTypeTemplateSelector}"/>
                 </Grid>
             </Border>
         </Grid>
-
 
         <Grid Grid.Row="3">
             <local:FooterPage/>

--- a/EcoSentinel/View/HistoricalDataPage.xaml
+++ b/EcoSentinel/View/HistoricalDataPage.xaml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:local="clr-namespace:EcoSentinel.View"
+    x:Class="EcoSentinel.HistoricalDataPage">
+
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="80"/>        
+            <RowDefinition Height="*"/>           
+            <RowDefinition Height="*"/>            
+            <RowDefinition Height="20"/>
+         
+        </Grid.RowDefinitions>
+
+        <Grid Grid.Row="0">
+            <local:HeaderPage/>
+        </Grid>
+
+        <Grid Grid.Row="1" >            
+            <Border x:Name="nodeFrame"
+                Grid.Row="0"
+                Margin="5"
+                Padding="0">
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                    </Grid.RowDefinitions>
+
+                    <Label Grid.Row="0" Text="Sensor List" Padding="8" Background="LightGray" />
+
+                    <ListView Grid.Row="1" Grid.RowSpan="3"
+                              ItemsSource="{Binding SensorData}">
+                        <ListView.ItemTemplate>
+                            <DataTemplate>
+                                <ViewCell>
+                                    <Frame Padding="8" Margin="4" >
+                                        <Label Text="{Binding siteName}" FontSize="18"/>
+                                        <Frame.GestureRecognizers>
+                                            <TapGestureRecognizer
+                                               Command="{Binding BindingContext.NavigateCommand, Source={x:Reference nodeFrame}}"  
+                                                CommandParameter="{Binding .}" />
+                                        </Frame.GestureRecognizers>
+                                    </Frame>
+                                </ViewCell>
+                            </DataTemplate>
+                        </ListView.ItemTemplate>
+                    </ListView>
+                </Grid>
+            </Border>
+        </Grid>
+
+        <Grid Grid.Row="2">
+            <Border x:Name="sensorDataFrame"
+            Grid.Row="0"
+            Grid.Column="0" 
+            Margin="5"
+            Padding="10">
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="*" />
+                        </Grid.RowDefinitions>
+
+                    <Grid Grid.Row="0"
+                          BackgroundColor="lightgray"
+                          ColumnDefinitions="*,*,*,*,*,*,*,*"
+                          Padding="5">
+                        <Label Grid.Column="0" Text="Sensor Type" FontSize="16" FontAttributes="Bold"/>
+                        <Label Grid.Column="1" Text="Zone" FontSize="16" FontAttributes="Bold"/>
+                        <Label Grid.Column="2" Text="Agglomeration" FontSize="16" FontAttributes="Bold"/>
+                        <Label Grid.Column="3" Text="Date" FontSize="16" FontAttributes="Bold"/>
+                        <Label Grid.Column="4" Text="Time" FontSize="16" FontAttributes="Bold"/>
+                        <Label Grid.Column="5" Text="NO₂" FontSize="16" FontAttributes="Bold"/>
+                        <Label Grid.Column="6" Text="SO₂" FontSize="16" FontAttributes="Bold"/>
+                        <Label Grid.Column="7" Text="PM2.5" FontSize="16" FontAttributes="Bold"/>
+                    </Grid>
+
+                    <CollectionView Grid.Row="1" ItemsSource="{Binding AirData}">
+                        <CollectionView.ItemTemplate>
+                            <DataTemplate>
+                                <Grid ColumnDefinitions="*,*,*,*,*,*,*,*">
+                                    <Label Grid.Column="0" Text="{Binding sensorType}" FontSize="14" Padding="5"/>
+                                    <Label Grid.Column="1" Text="{Binding zone}" FontSize="14" Padding="5"/>
+                                    <Label Grid.Column="2" Text="{Binding agglomeration}" FontSize="14" Padding="5"/>
+                                    <Label Grid.Column="3" Text="{Binding date}" FontSize="14" Padding="5"/>
+                                    <Label Grid.Column="4" Text="{Binding time}" FontSize="14" Padding="5"/>
+                                    <Label Grid.Column="5" Text="{Binding nitrogenDioxide}" FontSize="14" Padding="5"/>
+                                    <Label Grid.Column="6" Text="{Binding sulfurDioxide}" FontSize="14" Padding="5"/>
+                                    <Label Grid.Column="7" Text="{Binding pmTwoPointFive}" FontSize="14" Padding="5"/>
+                                </Grid>
+                            </DataTemplate>
+                        </CollectionView.ItemTemplate>
+                    </CollectionView>
+                </Grid>
+            </Border>
+        </Grid>
+
+
+        <Grid Grid.Row="3">
+            <local:FooterPage/>
+        </Grid>
+
+    </Grid>
+</ContentPage>

--- a/EcoSentinel/View/HistoricalDataPage.xaml.cs
+++ b/EcoSentinel/View/HistoricalDataPage.xaml.cs
@@ -7,6 +7,6 @@ public partial class HistoricalDataPage : ContentPage
 	public HistoricalDataPage()
 	{
 		InitializeComponent();
-		BindingContext = new HistoricalPageViewModel();
+		BindingContext = new HistoricalDataPageViewModel();
 	}
 }

--- a/EcoSentinel/View/HistoricalDataPage.xaml.cs
+++ b/EcoSentinel/View/HistoricalDataPage.xaml.cs
@@ -1,0 +1,12 @@
+using EcoSentinel.ViewModel;
+
+namespace EcoSentinel.View;
+
+public partial class HistoricalDataPage : ContentPage
+{
+	public HistoricalDataPage()
+	{
+		InitializeComponent();
+		BindingContext = new HistoricalPageViewModel();
+	}
+}

--- a/EcoSentinel/View/LandingPage.xaml
+++ b/EcoSentinel/View/LandingPage.xaml
@@ -80,6 +80,9 @@
                 BackgroundColor="LightBlue">
                 <Image Source="historical.png"
                        Aspect="AspectFit"/>
+                <Frame.GestureRecognizers>
+                    <TapGestureRecognizer Tapped="historicalFrameTapped" />
+                </Frame.GestureRecognizers>
             </Frame>
             <Frame
                 x:Name="adminFrame"

--- a/EcoSentinel/View/LandingPage.xaml.cs
+++ b/EcoSentinel/View/LandingPage.xaml.cs
@@ -29,4 +29,9 @@ public partial class LandingPage : ContentPage
 	{
 		Shell.Current.GoToAsync(nameof(AdministrationPage));
 	}
+
+	public void historicalFrameTapped(object sender, EventArgs e)
+	{
+		Shell.Current.GoToAsync(nameof(HistoricalDataPage));
+	}
 }

--- a/EcoSentinel/ViewModel/HistoricalDataPageViewModel.cs
+++ b/EcoSentinel/ViewModel/HistoricalDataPageViewModel.cs
@@ -1,0 +1,8 @@
+using System;
+
+namespace EcoSentinel.ViewModel;
+
+public class HistoricalDataPageViewModel
+{
+
+}

--- a/EcoSentinel/ViewModel/HistoricalDataPageViewModel.cs
+++ b/EcoSentinel/ViewModel/HistoricalDataPageViewModel.cs
@@ -1,8 +1,96 @@
 using System;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using EcoSentinel.Model;
 
-namespace EcoSentinel.ViewModel;
-
-public class HistoricalDataPageViewModel
+namespace EcoSentinel.ViewModel
 {
+    public partial class HistoricalDataPageViewModel : INotifyPropertyChanged
+    {
+        private DatabaseService _databaseService;
+        private ObservableCollection<SensorModel> _sensorData;
+        public ObservableCollection<AirDataModel> AirData { get; set; } = new();
+        public ObservableCollection<WaterDataModel> WaterData { get; set; } = new();
+        public ObservableCollection<WeatherDataModel> WeatherData { get; set; } = new();
+        public Command<SensorModel> NavigateCommand { get; }
+        private string _currentDataType;
+        public string CurrentDataType
+        {
+            get => _currentDataType;
+            set
+            {
+                _currentDataType = value;
+                OnPropertyChanged(nameof(CurrentDataType));
+                OnPropertyChanged(nameof(CurrentData));
+            }
+        }
 
+        public ObservableCollection<SensorModel> SensorData
+        {
+            get => _sensorData;
+            set
+            {
+                _sensorData = value;
+                OnPropertyChanged(nameof(SensorData));
+            }
+        }
+
+        public ObservableCollection<object> CurrentData
+        {
+            get
+            {
+                return CurrentDataType switch
+                {
+                    "air" => new ObservableCollection<object>(AirData),
+                    "water" => new ObservableCollection<object>(WaterData),
+                    "weather" => new ObservableCollection<object>(WeatherData),
+                    _ => new ObservableCollection<object>(),
+                };
+            }
+        }
+
+        public HistoricalDataPageViewModel()
+        {
+            _databaseService = new DatabaseService();
+            _sensorData = new ObservableCollection<SensorModel>();
+            NavigateCommand = new Command<SensorModel>(OnNavigate);
+            LoadSensorData();
+            LoadHistoricalData();
+        }
+
+        private void LoadSensorData()
+        {
+            var sensorData = _databaseService.PopulateSensorData();
+            SensorData = new ObservableCollection<SensorModel>(sensorData);
+        }
+
+        private void LoadHistoricalData()
+        {
+            var airData = _databaseService.PopulateAirData()
+                .OrderByDescending(x => x.date)
+                .ThenByDescending(x => x.time);
+            var waterData = _databaseService.PopulateWaterData()
+                .OrderByDescending(x => x.date)
+                .ThenByDescending(x => x.time);
+            var weatherData = _databaseService.PopulateWeatherData()
+                .OrderByDescending(x => x.date)
+                .ThenByDescending(x => x.time);
+            AirData = new ObservableCollection<AirDataModel>(airData);
+            WaterData = new ObservableCollection<WaterDataModel>(waterData);
+            WeatherData = new ObservableCollection<WeatherDataModel>(weatherData);
+        }
+
+        private void OnNavigate(SensorModel sensor)
+        {
+            Console.WriteLine($"Loading {sensor.sensorType} data...");
+            CurrentDataType = sensor.sensorType;
+        }
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+        protected virtual void OnPropertyChanged(string propertyName)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+    }
 }


### PR DESCRIPTION
Created the Historical Data Page and made this possible to navigate to from LandingPage and Flyout Menu

Modified Files
- AppShell - Added HistoricalDataPage to navigation
- MauiProgram - Added HistoricalDataPage to builder for navigation
- LandingPage - Added HistoricalDataPage to frames for navigation

New files
- HistoricalDataPage.xaml - Xaml design and bindings for HistoricalDataPage
- HistoricalDataPage.xaml.cs - Binds HistoricalDataPage xaml to HistoricalDataPageViewModel
- HistoricalDataPageViewModel.cs - Contains behaviour code and properties for HistoricalDataPage bindings and functionality
- DataTypeTemplateSelector.cs - contains behaviour and properties for dynamically generating the template used for each sensor type on the HistoricalDataPage

Dropped Functionality:
- Removed the Download and Report buttons as these features could not be implemented due to time constraints
- Removed the headers for the historical data as these were encountering a bug/issue being implemented dynamically and a solution to this would have overrun passed the time constraints
  - This can be implemented in a future iteration with suitable time for investigation